### PR TITLE
Do not use `this` for window object

### DIFF
--- a/example/demo.html
+++ b/example/demo.html
@@ -27,7 +27,7 @@
         onMousemove: function(e) {
           captured = e.target.outerHTML;
         },
-        onOverlayClicked: function() {
+        onClick: function() {
           document.querySelector('textarea').value = captured;
         }
       });

--- a/src/element-inspector.js
+++ b/src/element-inspector.js
@@ -140,4 +140,4 @@
     };
 
     global.ElementInspector = ElementInspector;
-})(this);
+})(typeof global !== 'undefined' ? global : typeof window !== 'undefined' ? window : {});


### PR DESCRIPTION
on babel(ES2015) `this` is not an window.

http://babeljs.io/faq/#why-is-this-being-remapped-to-undefined

> Babel assumes that all input code is an ES2015 module. ES2015 modules are implicitly strict mode so this means that top-level this is not window in the browser nor is it exports in node.

